### PR TITLE
Update sketchybar

### DIFF
--- a/mbp/sketchybar/home.nix
+++ b/mbp/sketchybar/home.nix
@@ -1,17 +1,19 @@
-{ pkgs, ... }:
 {
+  pkgs,
+  lib,
+  ...
+}: {
   xdg.configFile."sketchybar" = {
     source = ./config;
     recursive = true;
-    onChange = "${pkgs.sketchybar}/bin/sketchybar --reload";
+    onChange = "${lib.getExe pkgs.sketchybar} --reload";
   };
-  xdg.configFile."sketchybar/helpers/app_icons.lua" = with pkgs.generated; {
-    source = sketchybar_app_font.src;
-    onChange = "${pkgs.sketchybar}/bin/sketchybar --reload";
+  xdg.configFile."sketchybar/helpers/app_icons.lua" = {
+    source = "${pkgs.sketchybar-app-font}/lib/sketchybar-app-font/icon_map.lua";
   };
   xdg.configFile."sketchybar/sketchybarrc" = {
     text = ''
-      #!/usr/bin/env ${pkgs.lua54Packages.lua}/bin/lua
+      #!/usr/bin/env ${lib.getExe pkgs.lua54Packages.lua}
 
       package.cpath = package.cpath .. ";${pkgs.sbarlua}/lib/?.so"
 
@@ -20,6 +22,5 @@
       require("init")
     '';
     executable = true;
-    onChange = "${pkgs.sketchybar}/bin/sketchybar --reload";
   };
 }


### PR DESCRIPTION
- Use ., recursive = true for sketchybar directory → simpler source path.
- Replace with pkgs.generated and sketchybar_app_font.src with a direct reference to:
```
"${pkgs.sketchybar-app-font}/lib/sketchybar-app-font/icon_map.lua"
```
This directly points to the installed icon_map.lua file inside the Nix store, improving reliability and removing dependency on overlays.
- Replace hardcoded binary paths (/bin/sketchybar, /bin/lua) with:
```
${lib.getExe pkgs.sketchybar}
${lib.getExe pkgs.lua54Packages.lua}
```
→ makes the config cleaner and more robust.
- 	Remove unused onChange on app_icons.lua and sketchybarrc where not necessary.
