### PR TITLE
[2/5] fix: caddy cert load order & host header

### DIFF
--- a/hosts/homelab/microvms/vms/caddy-proxy.nix
+++ b/hosts/homelab/microvms/vms/caddy-proxy.nix
@@ -29,10 +29,17 @@ in
         hostName = "https://${httpsHost}";
         extraConfig = ''
           tls ${vmCert.certPath} ${vmCert.keyPath}
-          reverse_proxy ${upstream}
+          reverse_proxy ${upstream} {
+            header_up Host {upstream_hostport}
+          }
         '';
       };
     };
+  };
+
+  systemd.services.caddy = {
+    after = [ "run-homelab\\x2dcerts.mount" ];
+    requires = [ "run-homelab\\x2dcerts.mount" ];
   };
 
   systemd.services.caddy-daily-reload = {


### PR DESCRIPTION
**Stack:**

* https://github.com/PhotonQuantum/flakes/pull/22
* https://github.com/PhotonQuantum/flakes/pull/23
* https://github.com/PhotonQuantum/flakes/pull/24
* https://github.com/PhotonQuantum/flakes/pull/25
* https://github.com/PhotonQuantum/flakes/pull/26


---

fix: caddy cert load order & host header

